### PR TITLE
Debug login redirect issue

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -170,6 +170,7 @@ const char* NET_CGI_Handler(int iIndex, int iNumParams, char *pcParam[], char *p
 #include "lwip/ip_addr.h"
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 
 
@@ -570,6 +571,11 @@ void httpd_post_finished(void *connection, char *response_uri, u16_t response_ur
 {
     // Если это был login — перенаправим по результату авторизации
     if (login_request_active) {
+        // Гарантируем NUL-терминацию буфера перед разбором
+        if (login_buf_len >= sizeof(login_buf)) {
+            login_buf_len = sizeof(login_buf) - 1;
+        }
+        login_buf[login_buf_len] = '\0';
         if (response_uri && response_uri_len) {
             // Разобрать накопленный буфер
             char user[32]={0}, pass[32]={0};


### PR DESCRIPTION
Ensure NUL-termination of the login POST buffer and include `<ctype.h>` to fix login always failing due to incorrect parsing of credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-23e2b749-356f-4ac2-bf57-669606df48c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23e2b749-356f-4ac2-bf57-669606df48c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

