### PR TITLE
Настройка дисплея и сетевых параметров

### DIFF
--- a/Core/Inc/ssd1306_driver/ssd1306.h
+++ b/Core/Inc/ssd1306_driver/ssd1306.h
@@ -215,6 +215,18 @@ SSD1306_Error_t ssd1306_FillBuffer(uint8_t* buf, uint32_t len);
 
 void ssd1306_FillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, SSD1306_COLOR color);
 
+/**
+ * @brief Enable or disable additional 180° rotation of the display mapping.
+ * @param on 0 to disable (0°), non-zero to enable (180°).
+ */
+void ssd1306_SetRotation180(const uint8_t on);
+
+/**
+ * @brief Get current 180° rotation flag.
+ * @return 1 if 180° rotation is enabled, 0 otherwise.
+ */
+uint8_t ssd1306_GetRotation180(void);
+
 _END_STD_C
 
 #endif // __SSD1306_H__

--- a/Core/Src/ssd1306_driver/ssd1306.c
+++ b/Core/Src/ssd1306_driver/ssd1306.c
@@ -28,14 +28,24 @@
 #define SSD1306_ROTATED_WIDTH  (SSD1306_HEIGHT)
 #define SSD1306_ROTATED_HEIGHT (SSD1306_WIDTH)
 
-/* Map logical (lx,ly) -> physical (px,py) for 90° clockwise rotation:
- * px = physical_x = W - 1 - ly
- * py = physical_y = lx
+/* Runtime 180° rotation flag (in addition to fixed 90° mapping) */
+static uint8_t s_rotation_180 = 0;
+
+/* Map logical (lx,ly) -> physical (px,py) for 90° clockwise base rotation.
+ * If s_rotation_180 is set, apply an additional 180° flip in physical space.
  */
-// Поворот 90° против часовой стрелки
+// Поворот 90° против часовой стрелки + опционально 180°
 static inline void ssd1306_map_logical_to_physical(uint8_t lx, uint8_t ly, uint8_t *px, uint8_t *py) {
-    *px = ly;
-    *py = (uint8_t)(SSD1306_HEIGHT - 1 - lx);
+    uint8_t _px = ly;
+    uint8_t _py = (uint8_t)(SSD1306_HEIGHT - 1 - lx);
+
+    if (s_rotation_180) {
+        _px = (uint8_t)(SSD1306_WIDTH  - 1 - _px);
+        _py = (uint8_t)(SSD1306_HEIGHT - 1 - _py);
+    }
+
+    *px = _px;
+    *py = _py;
 }
 
 
@@ -627,6 +637,14 @@ void ssd1306_SetDisplayOn(const uint8_t on) {
 
 uint8_t ssd1306_GetDisplayOn() {
     return SSD1306.DisplayOn;
+}
+
+void ssd1306_SetRotation180(const uint8_t on) {
+    s_rotation_180 = on ? 1U : 0U;
+}
+
+uint8_t ssd1306_GetRotation180(void) {
+    return s_rotation_180;
 }
 
 void ssd1306_FillRect(uint8_t x, uint8_t y, uint8_t w, uint8_t h, SSD1306_COLOR color) {


### PR DESCRIPTION
Add display rotation, DHCP submenu, and refined Reset/Reboot options to OLED settings.

This PR implements user-requested features to enhance device configuration:
- `Display rotation` allows switching between 0° and 180° orientation.
- `Reset (reboot)` performs a soft STM32 reboot.
- `Reboot to defaults` performs a factory reset, setting network parameters to 192.168.0.254/24, gateway 192.168.0.1, DHCP off, and resetting time/date to epoch.
- `DHCP` is now a submenu with explicit On/Off selection.
- All critical actions (`Reset`, `Reboot to defaults`) include confirmation prompts with descriptive text.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc81ead1-bad4-4360-b386-5466d2403d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc81ead1-bad4-4360-b386-5466d2403d40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

